### PR TITLE
Fixes to get minecraft client 1.16.1 to work on FreeBSD12.1-RELEASE-p6 amd64

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -930,6 +930,7 @@
                 </not>
             </condition>
 
+<!--
             <parallel threadsPerProcessor="4" failonany="true">
                 <get-release url="linux/x64/lib@{native-library}.so" if:set="auto-natives"/>
                 <get-release url="macosx/x64/lib@{native-library}.dylib" if:set="auto-natives"/>
@@ -957,6 +958,7 @@
                 <natives-jar name="@{name}" title="@{title}" platform="macos" extension=".dylib"/>
                 <natives-jar name="@{name}" title="@{title}" platform="windows" extension=".dll"/>
             </parallel>
+-->
         </sequential>
     </macrodef>
 

--- a/config/build-definitions.xml
+++ b/config/build-definitions.xml
@@ -288,8 +288,8 @@ This script is included in /build.xml and /config/update-dependencies.xml.
         <attribute name="sources" default="true"/>
 
         <sequential>
-            <get-quiet name="@{name}" url="http://central.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.jar" dest="${lib}/java/@{artifact}.jar" skipexisting="false"/>
-            <get-quiet name="@{name}" url="http://central.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}-sources.jar" dest="${lib}/java/@{artifact}-sources.jar" skipexisting="false" if:true="@{sources}"/>
+            <get-quiet name="@{name}" url="https://repo1.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}.jar" dest="${lib}/java/@{artifact}.jar" skipexisting="false"/>
+            <get-quiet name="@{name}" url="https://repo1.maven.org/maven2/@{group}/@{artifact}/@{version}/@{artifact}-@{version}-sources.jar" dest="${lib}/java/@{artifact}-sources.jar" skipexisting="false" if:true="@{sources}"/>
         </sequential>
     </macrodef>
 

--- a/config/linux/build.xml
+++ b/config/linux/build.xml
@@ -22,8 +22,8 @@
     <macrodef name="compile">
         <attribute name="dest" default="${dest}"/>
         <attribute name="lang" default="c"/>
-        <attribute name="gcc.exec" default="gcc${gcc.suffix}"/>
-        <attribute name="gpp.exec" default="g++${gcc.suffix}"/>
+        <attribute name="gcc.exec" default="cc${gcc.suffix}"/>
+        <attribute name="gpp.exec" default="c++${gcc.suffix}"/>
         <attribute name="lto" default="-flto"/>
         <attribute name="flags" default=""/>
         <attribute name="simple" default="false"/>
@@ -64,8 +64,8 @@
         <attribute name="module"/>
         <attribute name="linker" default="gcc"/>
         <attribute name="lang" default="c"/>
-        <attribute name="gcc.exec" default="gcc${gcc.suffix}"/>
-        <attribute name="gpp.exec" default="g++${gcc.suffix}"/>
+        <attribute name="gcc.exec" default="cc${gcc.suffix}"/>
+        <attribute name="gpp.exec" default="c++${gcc.suffix}"/>
         <attribute name="flags" default="-Werror -Wfatal-errors"/>
         <attribute name="simple" default="false"/>
         <element name="beforeCompile" optional="true"/>
@@ -139,8 +139,8 @@
 
     <macrodef name="build_simple">
         <attribute name="module"/>
-        <attribute name="gcc.exec" default="gcc${gcc.suffix}"/>
-        <attribute name="gpp.exec" default="g++${gcc.suffix}"/>
+        <attribute name="gcc.exec" default="cc${gcc.suffix}"/>
+        <attribute name="gpp.exec" default="c++${gcc.suffix}"/>
         <sequential>
             <build module="@{module}" gcc.exec="@{gcc.exec}" gpp.exec="@{gpp.exec}" simple="true" if:true="${binding.@{module}}"/>
         </sequential>

--- a/modules/lwjgl/stb/src/generated/c/org_lwjgl_stb_STBVorbis.c
+++ b/modules/lwjgl/stb/src/generated/c/org_lwjgl_stb_STBVorbis.c
@@ -6,7 +6,7 @@
 #include "common_tools.h"
 DISABLE_WARNINGS()
 #ifdef LWJGL_LINUX
-    #include <alloca.h>
+    #include <stdlib.h>
 #endif
 #include "stb_vorbis.c"
 ENABLE_WARNINGS()


### PR DESCRIPTION
Change compiler from gcc/g++ to cc/c++
Fix maven remote repo url
Stop downloading libraries for different platforms (urls dont work and they are not needed juts to build the library)

Builds and runs with openjdk8-8.252.09.1