### PR TITLE
Backport GLFWImage.malloc(int, MemoryStack) as new MC needs it

### DIFF
--- a/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFWImage.java
+++ b/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFWImage.java
@@ -238,6 +238,10 @@ public class GLFWImage extends Struct implements NativeResource {
     public static GLFWImage.Buffer mallocStack(int capacity) {
         return mallocStack(capacity, stackGet());
     }
+    // backported
+    public static GLFWImage.Buffer malloc(int capacity, MemoryStack stack) {
+        return wrap(Buffer.class, stack.nmalloc(ALIGNOF, capacity * SIZEOF), capacity);
+    }
 
     /**
      * Returns a new {@link GLFWImage.Buffer} instance allocated on the thread-local {@link MemoryStack} and initializes all its bits to zero.


### PR DESCRIPTION
Copy-pasted from https://github.com/LWJGL-CI/lwjgl3/blob/master/modules/lwjgl/glfw/src/generated/java/org/lwjgl/glfw/GLFWImage.java

Please merge